### PR TITLE
Export at 30 fps

### DIFF
--- a/io_alamo_tools/export_ala.py
+++ b/io_alamo_tools/export_ala.py
@@ -227,7 +227,7 @@ def create_anim_info_chunk(armature):
     chunk += struct.pack("<I", animLength + 1)  # number of animation frames
 
     chunk += b'\x02\x04'  # mini chunk length
-    chunk += struct.pack("<f", bpy.context.scene.render.fps)
+    chunk += struct.pack("<f", 30)
 
     chunk += b'\x03\x04'  # mini chunk length
     chunk += struct.pack("<I", len(


### PR DESCRIPTION
EaW requires animations to be at 30fps anyway, makes sense to set it and not grab blender settings